### PR TITLE
Update STM32CubeF0 dependency from 1.7.0 to 1.11.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,10 @@ OBJS = $(patsubst $(SRCDIR)/%.c, $(OBJDIR)/%.o, $(wildcard $(SRCDIR)/*.c))
 OBJS += $(patsubst $(SRCDIR)/%.s, $(OBJDIR)/%.o, $(wildcard $(SRCDIR)/*.s))
 
 # STM32Cube variables
-CUBELIBDIR = $(LIBDIR)/STM32Cube_FW_F0_V1.7.0
+CUBELIBDIR = $(LIBDIR)/STM32Cube_FW_F0_V1.11.0
 CUBEOBJDIR = $(LIBDIR)/stm32cube
 CUBELIB = $(CUBEOBJDIR)/stm32cube.a
+HAL_CAN_LEGACY_OBJ = $(CUBEOBJDIR)/stm32f0xx_hal_can_legacy.o
 HAL_SRCDIR = $(CUBELIBDIR)/Drivers/STM32F0xx_HAL_Driver/Src
 HAL_SRCS = $(filter-out $(wildcard $(HAL_SRCDIR)/*template.c), $(wildcard $(HAL_SRCDIR)/*.c))
 HAL_OBJS = $(patsubst $(HAL_SRCDIR)/%.c, $(CUBEOBJDIR)/%.o, $(HAL_SRCS))
@@ -84,8 +85,11 @@ $(OBJDIR)/%.o: $(SRCDIR)/%.s
 	@mkdir -p $(OBJDIR)
 	$(CC) $(CFLAGS) $(INCLUDE) -MMD -o $@ -c $<
 
+$(HAL_CAN_LEGACY_OBJ): $(HAL_SRCDIR)/Legacy/stm32f0xx_hal_can.c
+	$(CC) $(CFLAGSLIB) $(INCLUDE) -o $@ -c $<
+
 # STM32Cube dependencies
-$(CUBELIB): $(HAL_OBJS) $(USB_OBJS)
+$(CUBELIB): $(HAL_OBJS) $(USB_OBJS) $(HAL_CAN_LEGACY_OBJ)
 	$(AR) -r $@ $^
 
 $(CUBEOBJDIR)/%.o: $(HAL_SRCDIR)/%.c

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ cd canalyze-fw
 $ mkdir lib
 ```
 Download and unzip
-[STM32CubeF0](http://www.st.com/en/embedded-software/stm32cubef0.html) to lib/.
+[STM32CubeF0 v1.11.0](http://www.st.com/en/embedded-software/stm32cubef0.html) to lib/.
 
 Connect the BOOT pins and press reset. Then run
 ```shell

--- a/inc/stm32f0xx_hal_conf.h
+++ b/inc/stm32f0xx_hal_conf.h
@@ -52,7 +52,8 @@
   */
 #define HAL_MODULE_ENABLED
 /* #define HAL_ADC_MODULE_ENABLED */
-#define HAL_CAN_MODULE_ENABLED
+/* #define HAL_CAN_MODULE_ENABLED */
+#define HAL_CAN_LEGACY_MODULE_ENABLED
 /*#define HAL_CEC_MODULE_ENABLED*/
 /* #define HAL_COMP_MODULE_ENABLED */
 #define HAL_CORTEX_MODULE_ENABLED
@@ -208,6 +209,10 @@
 #ifdef HAL_CAN_MODULE_ENABLED
  #include "stm32f0xx_hal_can.h"
 #endif /* HAL_CAN_MODULE_ENABLED */
+
+#ifdef HAL_CAN_LEGACY_MODULE_ENABLED
+#include "Legacy/stm32f0xx_hal_can_legacy.h"
+#endif
 
 #ifdef HAL_CEC_MODULE_ENABLED
  #include "stm32f0xx_hal_cec.h"


### PR DESCRIPTION
A few existing issues (#1 , #7) surface the need to depend on a newer version of STM32CubeF0. This change bumps this dependency to the latest major version. As of release v1.7.7 of the STM32f0xx_hal_driver, a new, incompatible version CAN HAL API was implemented. This induces a mandatory code change which requires users to opt into using the legacy CAN HAL API. This PR acts as a stop gap by allowing consumers to use the latest STMCubeF0 artifacts while opting into using the legacy api.



STM32 HAL Release 1.7.7
https://github.com/STMicroelectronics/stm32f0xx_hal_driver/commit/5fd31c52559a593dd9038c4abb4b85faeac728c6